### PR TITLE
Added batchCreate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dynamo Record
 
-This package aims to provide a *“humanized"* and more readable support of DynamoDB DocumentClient.
+This package aims to provide a _“humanized"_ and more readable support of DynamoDB DocumentClient.
 
 ## Getting started
 
@@ -96,6 +96,21 @@ Extend: [put()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB
 ### Parameters
 
 - `createData` **object** with data to add into table.
+- `config` **optional** - **object** with DocumentClient params.
+
+## batchCreate
+
+**Add an array of items**
+
+```javascript
+repo.batchCreate(createData, config);
+```
+
+Extend: [batchWrite()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#batchWriteItem-property)
+
+### Parameters
+
+- `createData` **array** of items to add into table.
 - `config` **optional** - **object** with DocumentClient params.
 
 ## update

--- a/src/dynamoRecord.js
+++ b/src/dynamoRecord.js
@@ -210,6 +210,35 @@ export class DynamoRecord {
   }
 
   /**
+   * batchCreate() add items into table
+   * @param {*} createData array of data to store into table max of 25 items
+   * @param {*} config an object with params for the request. (https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#batchWriteItem-property)
+   */
+  batchCreate(createData: Object[], config?: Object): Promise<any> {
+    return new Promise((resolve, reject) => {
+      let params: Object = {
+        RequestItems: {
+          [this.tableName]: createData.map(item => ({
+            PutRequest: { Item: item }
+          }))
+        }
+      };
+
+      if (config) {
+        params = assignConfig(params, config);
+      }
+
+      this.dynamoClient.batchWrite(params, (error: any, data: any) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(data);
+        }
+      });
+    });
+  }
+
+  /**
    * update() an item into table based on his primary key.
    * @param {*} primaryKey
    * @param {*} updateData


### PR DESCRIPTION
# Current limitations

- Unable to batch on multiple tables at once because of dynamo-record one table initialization constructor
- Not able to perform other action than putRequest because of simplicty

# How to improve (imo)

- Allow array of tables name in the constructor
- Improve the createData parameter in batchCreate to allow definition of different actions (putRequests and deleteRequest)
- or add batchDelete