### PR TITLE
[Feature] Deep update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ Extend: [batchWrite()](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/D
 
 ## update
 
-**Update an item based on his primary key**
+**Deep update an item based on his primary key**
+
+The updated object must have a full existing tree of all nested object before the update. _DynamoDB_ can't update a property and create it's parent object on the same request.
+
+If user wants to update a whole object without knowing the nested content, he can pass a custom config through _updateExpression_, _expressionAttributeNames_ and _expressionAttributeValues_.
 
 ```javascript
 repo.update(primaryKey, updateData, config);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "aws-sdk": "^2.382.0",
+    "flat": "^4.1.0",
     "lodash": "^4.17.11"
   }
 }

--- a/src/dynamoRecord.js
+++ b/src/dynamoRecord.js
@@ -302,8 +302,6 @@ export class DynamoRecord {
         params = assignConfig(params, config);
       }
 
-      console.log("dynamorecord", JSON.stringify({ params }));
-
       this.dynamoClient.update(params, (error: any, data: any) => {
         if (error) {
           reject(error);

--- a/src/dynamoRecord.js
+++ b/src/dynamoRecord.js
@@ -1,14 +1,15 @@
 // @flow
 
 import { DynamoDB } from "aws-sdk";
-import { forEach, upperFirst, join, isArray, size } from "lodash";
+import _ from "lodash";
+import { flatten } from "flat";
 import { type DynamoDBGetParams, type DynamoDBQueryParams } from "./types";
 
 const assignConfig = (params: Object, config: Object): Object => {
   const paramsToReturn = { ...params };
 
-  forEach(config, (value, key) => {
-    paramsToReturn[upperFirst(key)] = value;
+  _.forEach(config, (value, key) => {
+    paramsToReturn[_.upperFirst(key)] = value;
   });
 
   return paramsToReturn;
@@ -78,10 +79,10 @@ export class DynamoRecord {
 
         // Create an array with each primary key part
         // Assign :key / value (data interpolation syntax from Dynamo) to ExpressionAttributeValues
-        forEach(primaryKey, (value, key) => {
+        _.forEach(primaryKey, (value, key) => {
           params.ExpressionAttributeNames["#" + key] = key;
           // Between attributes
-          if (isArray(value) && value.length === 2) {
+          if (_.isArray(value) && value.length === 2) {
             primaryKeyArray.push(`#${key} BETWEEN :${key}Start AND :${key}End`);
             value.forEach((v, k) => {
               if (k === 0) {
@@ -97,7 +98,7 @@ export class DynamoRecord {
         });
 
         // Join with 'AND' each primary key part
-        params.KeyConditionExpression = join(primaryKeyArray, " AND ");
+        params.KeyConditionExpression = _.join(primaryKeyArray, " AND ");
       }
 
       if (
@@ -107,10 +108,10 @@ export class DynamoRecord {
       ) {
         params.FilterExpression = filterExpression.condition;
 
-        forEach(filterExpression.keys, (value, key) => {
+        _.forEach(filterExpression.keys, (value, key) => {
           params.ExpressionAttributeNames["#" + key] = key;
           // Between attributes
-          if (isArray(value) && value.length === 2) {
+          if (_.isArray(value) && value.length === 2) {
             value.forEach((v, k) => {
               if (k === 0) {
                 params.ExpressionAttributeValues[":" + key + "Start"] = v;
@@ -124,11 +125,11 @@ export class DynamoRecord {
         });
       }
 
-      if (size(params.ExpressionAttributeNames) === 0) {
+      if (_.size(params.ExpressionAttributeNames) === 0) {
         delete params.ExpressionAttributeNames;
       }
 
-      if (size(params.ExpressionAttributeValues) === 0) {
+      if (_.size(params.ExpressionAttributeValues) === 0) {
         delete params.ExpressionAttributeValues;
       }
 
@@ -255,24 +256,53 @@ export class DynamoRecord {
       };
 
       if (updateData) {
-        const updateExpression: string[] = [];
+        const updateExpression = [];
+        // Flatten the nested object to a 'key1.keyA': 'valueI' map but preserve array
+        const dataPath = flatten(updateData, { safe: true });
 
         // Create an array with each attributes (#key = :key)
         // Assign #key / key (data interpolation syntax from Dynamo) to ExpressionAttributeNames
         // Assign :key / value (data interpolation syntax from Dynamo) to ExpressionAttributeValues
-        forEach(updateData, (value, key) => {
-          updateExpression.push(`#${key} = :${key}`);
-          params.ExpressionAttributeNames["#" + key] = key;
-          params.ExpressionAttributeValues[":" + key] = value;
+        const keyCounter = {};
+        _.forEach(dataPath, (value, path) => {
+          const keys = path.split(".");
+
+          // Get the key of the value to update
+          let valueKey = keys[keys.length - 1];
+
+          // Check if the value was used for an other item in the update object
+          keyCounter[valueKey] = keyCounter[valueKey]
+            ? keyCounter[valueKey] + 1
+            : 1;
+          if (params.ExpressionAttributeValues[":" + valueKey] !== undefined) {
+            // Key already used so add key counter to the string
+            valueKey = `${valueKey}_${keyCounter[valueKey]}`;
+          }
+          params.ExpressionAttributeValues[":" + valueKey] = value;
+
+          // Construct the update expression for the value key with the path
+          let itemUpdateExpression = "";
+          keys.forEach((key, keyIndex) => {
+            params.ExpressionAttributeNames[`#${key}`] = key;
+            itemUpdateExpression += `#${key}`;
+            if (keyIndex !== keys.length - 1) {
+              itemUpdateExpression += ".";
+            }
+          });
+          itemUpdateExpression += ` = :${valueKey}`;
+
+          updateExpression.push(itemUpdateExpression);
         });
 
-        // Join with ',' each attributes
-        params.UpdateExpression = `set ${join(updateExpression, ", ")}`;
+        // Join with ',' each attributes path
+        params.UpdateExpression = `set ${_.join(updateExpression, ", ")}`;
       }
 
       if (config) {
         params = assignConfig(params, config);
       }
+
+      console.log("dynamorecord", JSON.stringify({ params }));
 
       this.dynamoClient.update(params, (error: any, data: any) => {
         if (error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,13 @@ flat-cache@^1.2.1:
     rimraf "~2.6.2"
     write "^0.2.1"
 
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+  dependencies:
+    is-buffer "~2.0.3"
+
 flow-bin@^0.89.0:
   version "0.89.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.89.0.tgz#6bd29c2af7e0f429797f820662f33749105c32fa"
@@ -1852,6 +1859,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Add deep update by default on update method.
The updated object must have a full existing tree of all nested object before the update. DynamoDB can't update a property and create it's parent object on the same request.

If user wants to update a whole object without knowing the nested content, he can pass a custom config through updateExpression, expressionAttributeNames and expressionAttributeValues.